### PR TITLE
Add Moose to Inspection & Agriculture worlds

### DIFF
--- a/cpr_agriculture_gazebo/launch/spawn_moose.launch
+++ b/cpr_agriculture_gazebo/launch/spawn_moose.launch
@@ -1,0 +1,11 @@
+<launch>
+  <arg name="x" default="0.0"/>
+  <arg name="y" default="-10.0"/>
+  <arg name="z" default="5.0"/>
+
+  <include file="$(find moose_gazebo)/launch/spawn_moose.launch">
+    <arg name="x" value="$(arg x)"/>
+    <arg name="y" value="$(arg y)"/>
+    <arg name="z" value="$(arg z)"/>
+  </include>
+</launch>

--- a/cpr_agriculture_gazebo/package.xml
+++ b/cpr_agriculture_gazebo/package.xml
@@ -13,7 +13,7 @@
   <exec_depend>husky_gazebo</exec_depend>
   <exec_depend>jackal_gazebo</exec_depend>
   <exec_depend>warthog_gazebo</exec_depend>
-  <exec_depend>heron_gazebo</exec_depend>
+  <exec_depend>moose_gazebo</exec_depend>
 
   <export>
   </export>

--- a/cpr_agriculture_gazebo/worlds/actually_empty_world.world
+++ b/cpr_agriculture_gazebo/worlds/actually_empty_world.world
@@ -23,6 +23,11 @@
       <ambient>1 1 1 1</ambient>
       <background>1 1 1 1</background>
       <shadows>1</shadows>
+      <sky>
+        <clouds>
+          <speed>12</speed>
+        </clouds>
+      </sky>
     </scene>
     <spherical_coordinates>
       <surface_model>EARTH_WGS84</surface_model>

--- a/cpr_inspection_gazebo/launch/spawn_moose.launch
+++ b/cpr_inspection_gazebo/launch/spawn_moose.launch
@@ -1,0 +1,11 @@
+<launch>
+  <arg name="x" default="0.0"/>
+  <arg name="y" default="-10.0"/>
+  <arg name="z" default="5.0"/>
+
+  <include file="$(find moose_gazebo)/launch/spawn_moose.launch">
+    <arg name="x" value="$(arg x)"/>
+    <arg name="y" value="$(arg y)"/>
+    <arg name="z" value="$(arg z)"/>
+  </include>
+</launch>


### PR DESCRIPTION
Moose was the only robot absent from any of the sims, so add it to the larger outdoor environments.  Also add the blue sky & clouds to the agriculture sim to make it look nicer.