### PR TITLE
Fix catkin_make install

### DIFF
--- a/cpr_empty_gazebo/CMakeLists.txt
+++ b/cpr_empty_gazebo/CMakeLists.txt
@@ -10,10 +10,6 @@ include_directories(
   ${catkin_INCLUDE_DIRS}
 )
 
-install(DIRECTORY launch meshes rviz scripts urdf worlds
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-)
-
-install(FILES model.config
+install(DIRECTORY launch rviz urdf worlds
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )


### PR DESCRIPTION
This PR fixes the compilation with `catkin_make install` where some resources were not found because they don't exist.